### PR TITLE
Add Gemini API response storage and display

### DIFF
--- a/logs.html
+++ b/logs.html
@@ -19,6 +19,7 @@
             <tr>
                 <th>Timestamp</th>
                 <th>Prompt</th>
+                <th>Response</th>
                 <th>Is Variation</th>
                 <th>IP Address</th>
             </tr>
@@ -35,13 +36,14 @@
                 .then(data => {
                     const tableBody = document.getElementById('logs-table-body');
                     if (data.length === 0) {
-                        tableBody.innerHTML = '<tr><td colspan="4">No logs found.</td></tr>';
+                        tableBody.innerHTML = '<tr><td colspan="5">No logs found.</td></tr>';
                         return;
                     }
                     const rows = data.map(log => `
                         <tr>
                             <td>${new Date(log.timestamp).toLocaleString()}</td>
                             <td>${log.prompt}</td>
+                            <td>${(log.response && log.response.candidates && log.response.candidates[0]?.content?.parts[0]?.text) || ''}</td>
                             <td>${log.isVariation}</td>
                             <td>${log.ip}</td>
                         </tr>
@@ -51,7 +53,7 @@
                 .catch(error => {
                     console.error('Error fetching logs:', error);
                     const tableBody = document.getElementById('logs-table-body');
-                    tableBody.innerHTML = '<tr><td colspan="4">Error loading logs.</td></tr>';
+                    tableBody.innerHTML = '<tr><td colspan="5">Error loading logs.</td></tr>';
                 });
         });
     </script>

--- a/server.js
+++ b/server.js
@@ -18,18 +18,7 @@ app.post('/API/GEMINI', async (req, res) => {
     const userPrompt = req.body.prompt;
     const isVariation = req.body.isVariation;
 
-    try {
-        const db = getDB();
-        await db.collection('prompts').insertOne({
-            prompt: userPrompt,
-            isVariation,
-            timestamp: new Date(),
-            ip: req.ip
-        });
-    } catch (dbError) {
-        console.error('Error saving prompt to DB:', dbError);
-        // We can choose to not fail the whole request if DB write fails
-    }
+    let geminiData;
 
     if (!apiKey) {
         return res.status(500).json({ error: 'API key not configured on server.' });
@@ -63,8 +52,23 @@ app.post('/API/GEMINI', async (req, res) => {
             body: JSON.stringify(payload)
         });
 
-        const data = await geminiResponse.json();
-        res.json(data); // Forward Gemini's response to the frontend
+        geminiData = await geminiResponse.json();
+
+        try {
+            const db = getDB();
+            await db.collection('prompts').insertOne({
+                prompt: userPrompt,
+                response: geminiData,
+                isVariation,
+                timestamp: new Date(),
+                ip: req.ip
+            });
+        } catch (dbError) {
+            console.error('Error saving prompt to DB:', dbError);
+            // We can choose to not fail the whole request if DB write fails
+        }
+
+        res.json(geminiData); // Forward Gemini's response to the frontend
 
     } catch (error) {
         console.error('Error calling Gemini API:', error);


### PR DESCRIPTION
## Summary
- log Gemini API responses in the database
- show saved responses on the logs page

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6862df4bd3f0832b9d84384ebea49c14