### PR TITLE
Add vitest setup and sample API test

### DIFF
--- a/logs.html
+++ b/logs.html
@@ -19,6 +19,7 @@
             <tr>
                 <th>Timestamp</th>
                 <th>Prompt</th>
+                <th>Response</th>
                 <th>Is Variation</th>
                 <th>IP Address</th>
             </tr>
@@ -35,13 +36,14 @@
                 .then(data => {
                     const tableBody = document.getElementById('logs-table-body');
                     if (data.length === 0) {
-                        tableBody.innerHTML = '<tr><td colspan="4">No logs found.</td></tr>';
+                        tableBody.innerHTML = '<tr><td colspan="5">No logs found.</td></tr>';
                         return;
                     }
                     const rows = data.map(log => `
                         <tr>
                             <td>${new Date(log.timestamp).toLocaleString()}</td>
                             <td>${log.prompt}</td>
+                            <td>${(log.response && log.response.candidates && log.response.candidates[0]?.content?.parts[0]?.text) || ''}</td>
                             <td>${log.isVariation}</td>
                             <td>${log.ip}</td>
                         </tr>
@@ -51,7 +53,7 @@
                 .catch(error => {
                     console.error('Error fetching logs:', error);
                     const tableBody = document.getElementById('logs-table-body');
-                    tableBody.innerHTML = '<tr><td colspan="4">Error loading logs.</td></tr>';
+                    tableBody.innerHTML = '<tr><td colspan="5">Error loading logs.</td></tr>';
                 });
         });
     </script>

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "vitest run"
   },
   "keywords": [],
   "author": "",
@@ -14,5 +14,9 @@
     "express": "^5.1.0",
     "mongodb": "^6.5.0",
     "node-fetch": "^2.7.0"
+  },
+  "devDependencies": {
+    "supertest": "^6.3.3",
+    "vitest": "^1.0.0"
   }
 }

--- a/tests/api.test.js
+++ b/tests/api.test.js
@@ -1,0 +1,13 @@
+import { describe, it, expect } from 'vitest';
+import request from 'supertest';
+import { app } from '../server';
+
+describe('POST /API/GEMINI', () => {
+  it('returns 500 if API key is missing', async () => {
+    const prev = process.env.GEMINI_API_KEY;
+    delete process.env.GEMINI_API_KEY;
+    const res = await request(app).post('/API/GEMINI').send({ prompt: 'hello' });
+    expect(res.status).toBe(500);
+    process.env.GEMINI_API_KEY = prev;
+  });
+});


### PR DESCRIPTION
## Summary
- configure `vitest` as test runner
- export Express app in server.js for testing
- add a basic API test verifying missing API key handling

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6862df4bd3f0832b9d84384ebea49c14