### PR TITLE
Implement logs UI, auth, and Gemini response storage

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,6 @@
+GEMINI_API_KEY=your-gemini-key
+MONGO_URI=mongodb://localhost:27017/yourdb
+SESSION_SECRET=change-me
+ADMIN_USERNAME=admin
+ADMIN_PASSWORD=password
+

--- a/README.md
+++ b/README.md
@@ -6,8 +6,9 @@ This is a simple web application that allows users to interact with the Gemini A
 
 -   Frontend to send prompts to Google's Gemini API.
 -   Backend Express server to securely handle API requests.
--   Logs all prompts, variations, timestamps, and IP addresses to a MongoDB database.
--   A `/logs.html` page to view the submitted prompts.
+-   Logs all prompts, variations, timestamps, IP addresses, **and Gemini responses** to a MongoDB database.
+-   Simple user authentication. Login at `/login.html` before submitting prompts.
+-   A `/logs.html` page to view and filter submitted prompts.
 
 ## Setup
 
@@ -22,6 +23,8 @@ This is a simple web application that allows users to interact with the Gemini A
 3.  **Create a `.env` file** in the root directory. Copy the content from `.env.example` and fill in your details:
     -   `GEMINI_API_KEY`: Your API key from Google AI Studio.
     -   `MONGO_URI`: Your MongoDB connection string.
+    -   `SESSION_SECRET`: Secret used for session cookies.
+    -   `ADMIN_USERNAME` / `ADMIN_PASSWORD`: Credentials for logging in.
 
 4.  **Start the server:**
     ```bash

--- a/index.html
+++ b/index.html
@@ -116,6 +116,7 @@
         <header class="text-center mb-8">
             <h1 class="text-4xl md:text-5xl font-bold text-slate-900">The Red-Teamer's Guide</h1>
             <p class="text-lg text-slate-600 mt-2">A Field Manual for Adversarial Prompt Engineering</p>
+            <p class="mt-2"><a href="/login.html" class="underline text-sm text-red-600">Login</a></p>
         </header>
 
         <section id="attack-lab" class="mb-12">

--- a/login.html
+++ b/login.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Login</title>
+    <style>
+        body { font-family: sans-serif; display: flex; justify-content: center; align-items: center; height: 100vh; }
+        form { border: 1px solid #ccc; padding: 2em; border-radius: 4px; }
+        input { display: block; margin-bottom: 1em; width: 100%; }
+    </style>
+</head>
+<body>
+    <form id="login-form">
+        <h2>Login</h2>
+        <input type="text" id="username" placeholder="Username" required />
+        <input type="password" id="password" placeholder="Password" required />
+        <button type="submit">Login</button>
+        <p id="error" style="color:red"></p>
+    </form>
+    <script>
+        document.getElementById('login-form').addEventListener('submit', async (e) => {
+            e.preventDefault();
+            const username = document.getElementById('username').value;
+            const password = document.getElementById('password').value;
+            const res = await fetch('/login', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ username, password })
+            });
+            if (res.ok) {
+                window.location.href = '/index.html';
+            } else {
+                document.getElementById('error').textContent = 'Login failed';
+            }
+        });
+    </script>
+</body>
+</html>
+

--- a/logs.html
+++ b/logs.html
@@ -14,45 +14,91 @@
 </head>
 <body>
     <h1>Prompt Submission Logs</h1>
+
+    <form id="filter-form" style="margin-bottom:1em;">
+        <input type="text" id="filter-ip" placeholder="IP" />
+        <input type="text" id="filter-user" placeholder="User" />
+        <input type="date" id="filter-start" />
+        <input type="date" id="filter-end" />
+        <select id="sort-order">
+            <option value="desc">Newest</option>
+            <option value="asc">Oldest</option>
+        </select>
+        <button type="submit">Apply</button>
+    </form>
+
     <table>
         <thead>
             <tr>
                 <th>Timestamp</th>
+                <th>User</th>
                 <th>Prompt</th>
                 <th>Is Variation</th>
                 <th>IP Address</th>
+                <th>Response</th>
             </tr>
         </thead>
         <tbody id="logs-table-body">
             <!-- Rows will be inserted here by JavaScript -->
         </tbody>
     </table>
+    <div style="margin-top:1em;">
+        <button id="prev-page">Prev</button>
+        <span id="page-info"></span>
+        <button id="next-page">Next</button>
+    </div>
 
     <script>
         document.addEventListener('DOMContentLoaded', () => {
-            fetch('/logs')
-                .then(response => response.json())
-                .then(data => {
-                    const tableBody = document.getElementById('logs-table-body');
-                    if (data.length === 0) {
-                        tableBody.innerHTML = '<tr><td colspan="4">No logs found.</td></tr>';
-                        return;
-                    }
-                    const rows = data.map(log => `
-                        <tr>
-                            <td>${new Date(log.timestamp).toLocaleString()}</td>
-                            <td>${log.prompt}</td>
-                            <td>${log.isVariation}</td>
-                            <td>${log.ip}</td>
-                        </tr>
-                    `).join('');
-                    tableBody.innerHTML = rows;
-                })
-                .catch(error => {
-                    console.error('Error fetching logs:', error);
-                    const tableBody = document.getElementById('logs-table-body');
-                    tableBody.innerHTML = '<tr><td colspan="4">Error loading logs.</td></tr>';
-                });
+            const form = document.getElementById('filter-form');
+            const tableBody = document.getElementById('logs-table-body');
+            const pageInfo = document.getElementById('page-info');
+            let page = 1;
+            const limit = 20;
+
+            const load = () => {
+                const params = new URLSearchParams();
+                params.set('page', page);
+                params.set('limit', limit);
+                params.set('sort', document.getElementById('sort-order').value);
+                if (document.getElementById('filter-ip').value) params.set('ip', document.getElementById('filter-ip').value);
+                if (document.getElementById('filter-user').value) params.set('user', document.getElementById('filter-user').value);
+                if (document.getElementById('filter-start').value) params.set('start', document.getElementById('filter-start').value);
+                if (document.getElementById('filter-end').value) params.set('end', document.getElementById('filter-end').value);
+
+                fetch('/logs?' + params.toString())
+                    .then(res => res.json())
+                    .then(data => {
+                        if (data.prompts.length === 0) {
+                            tableBody.innerHTML = '<tr><td colspan="6">No logs found.</td></tr>';
+                            pageInfo.textContent = '';
+                            return;
+                        }
+                        const rows = data.prompts.map(log => `
+                            <tr>
+                                <td>${new Date(log.timestamp).toLocaleString()}</td>
+                                <td>${log.user || ''}</td>
+                                <td>${log.prompt}</td>
+                                <td>${log.isVariation}</td>
+                                <td>${log.ip}</td>
+                                <td>${(log.response && JSON.stringify(log.response)) || ''}</td>
+                            </tr>
+                        `).join('');
+                        tableBody.innerHTML = rows;
+                        pageInfo.textContent = `Page ${page} of ${Math.ceil(data.total / limit)}`;
+                    })
+                    .catch(err => {
+                        console.error('Error fetching logs:', err);
+                        tableBody.innerHTML = '<tr><td colspan="6">Error loading logs.</td></tr>';
+                        pageInfo.textContent = '';
+                    });
+            };
+
+            form.addEventListener('submit', e => { e.preventDefault(); page = 1; load(); });
+            document.getElementById('prev-page').addEventListener('click', () => { if (page > 1) { page--; load(); } });
+            document.getElementById('next-page').addEventListener('click', () => { page++; load(); });
+
+            load();
         });
     </script>
 </body>

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,33 @@
       "dependencies": {
         "dotenv": "^17.0.0",
         "express": "^5.1.0",
+        "express-session": "^1.18.1",
+        "mongodb": "^6.5.0",
         "node-fetch": "^2.7.0"
+      }
+    },
+    "node_modules/@mongodb-js/saslprep": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@mongodb-js/saslprep/-/saslprep-1.3.0.tgz",
+      "integrity": "sha512-zlayKCsIjYb7/IdfqxorK5+xUMyi4vOKcFy10wKJYc63NSdKI8mNME+uJqfatkPmOSMMUiojrL58IePKBm3gvQ==",
+      "license": "MIT",
+      "dependencies": {
+        "sparse-bitfield": "^3.0.3"
+      }
+    },
+    "node_modules/@types/webidl-conversions": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/@types/webidl-conversions/-/webidl-conversions-7.0.3.tgz",
+      "integrity": "sha512-CiJJvcRtIgzadHCYXw7dqEnMNRjhGZlYK05Mj9OyktqV8uVT8fD2BFOB7S1uwBE3Kj2Z+4UyPmFw/Ixgw/LAlA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/whatwg-url": {
+      "version": "11.0.5",
+      "resolved": "https://registry.npmjs.org/@types/whatwg-url/-/whatwg-url-11.0.5.tgz",
+      "integrity": "sha512-coYR071JRaHa+xoEvvYqvnIHaVqaYrLPbsufM9BF63HkwI5Lgmy2QR8Q5K/lYDYo5AK82wOvSOS0UsLTpTG7uQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/webidl-conversions": "*"
       }
     },
     "node_modules/accepts": {
@@ -45,6 +71,15 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/bson": {
+      "version": "6.10.4",
+      "resolved": "https://registry.npmjs.org/bson/-/bson-6.10.4.tgz",
+      "integrity": "sha512-WIsKqkSC0ABoBJuT1LEX+2HEvNmNKKgnTAyd0fL8qzK4SH2i9NXg+t08YtdZp/V9IZ33cxe3iV4yM0qg8lMQng==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=16.20.1"
       }
     },
     "node_modules/bytes": {
@@ -278,6 +313,46 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/express-session": {
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/express-session/-/express-session-1.18.1.tgz",
+      "integrity": "sha512-a5mtTqEaZvBCL9A9aqkrtfz+3SMDhOVUnjafjo+s7A9Txkq+SVX2DLvSp1Zrv4uCXa3lMSK3viWnh9Gg07PBUA==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "0.7.2",
+        "cookie-signature": "1.0.7",
+        "debug": "2.6.9",
+        "depd": "~2.0.0",
+        "on-headers": "~1.0.2",
+        "parseurl": "~1.3.3",
+        "safe-buffer": "5.2.1",
+        "uid-safe": "~2.1.5"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/express-session/node_modules/cookie-signature": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.7.tgz",
+      "integrity": "sha512-NXdYc3dLr47pBkpUCHtKSwIOQXLVn8dZEuywboCOJY/osA0wFSLlSawr3KN8qXJEyX66FcONTH8EIlVuK0yyFA==",
+      "license": "MIT"
+    },
+    "node_modules/express-session/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/express-session/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "license": "MIT"
+    },
     "node_modules/finalhandler": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.0.tgz",
@@ -471,6 +546,12 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/memory-pager": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/memory-pager/-/memory-pager-1.5.0.tgz",
+      "integrity": "sha512-ZS4Bp4r/Zoeq6+NLJpP+0Zzm0pR8whtGPf1XExKLJBAczGMnSi3It14OiNCStjQjM6NU1okjQGSxgEZN8eBYKg==",
+      "license": "MIT"
+    },
     "node_modules/merge-descriptors": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
@@ -502,6 +583,96 @@
       },
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/mongodb": {
+      "version": "6.17.0",
+      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-6.17.0.tgz",
+      "integrity": "sha512-neerUzg/8U26cgruLysKEjJvoNSXhyID3RvzvdcpsIi2COYM3FS3o9nlH7fxFtefTb942dX3W9i37oPfCVj4wA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@mongodb-js/saslprep": "^1.1.9",
+        "bson": "^6.10.4",
+        "mongodb-connection-string-url": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=16.20.1"
+      },
+      "peerDependencies": {
+        "@aws-sdk/credential-providers": "^3.188.0",
+        "@mongodb-js/zstd": "^1.1.0 || ^2.0.0",
+        "gcp-metadata": "^5.2.0",
+        "kerberos": "^2.0.1",
+        "mongodb-client-encryption": ">=6.0.0 <7",
+        "snappy": "^7.2.2",
+        "socks": "^2.7.1"
+      },
+      "peerDependenciesMeta": {
+        "@aws-sdk/credential-providers": {
+          "optional": true
+        },
+        "@mongodb-js/zstd": {
+          "optional": true
+        },
+        "gcp-metadata": {
+          "optional": true
+        },
+        "kerberos": {
+          "optional": true
+        },
+        "mongodb-client-encryption": {
+          "optional": true
+        },
+        "snappy": {
+          "optional": true
+        },
+        "socks": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/mongodb-connection-string-url": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mongodb-connection-string-url/-/mongodb-connection-string-url-3.0.2.tgz",
+      "integrity": "sha512-rMO7CGo/9BFwyZABcKAWL8UJwH/Kc2x0g72uhDWzG48URRax5TCIcJ7Rc3RZqffZzO/Gwff/jyKwCU9TN8gehA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/whatwg-url": "^11.0.2",
+        "whatwg-url": "^14.1.0 || ^13.0.0"
+      }
+    },
+    "node_modules/mongodb-connection-string-url/node_modules/tr46": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz",
+      "integrity": "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==",
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/mongodb-connection-string-url/node_modules/webidl-conversions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/mongodb-connection-string-url/node_modules/whatwg-url": {
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.2.0.tgz",
+      "integrity": "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==",
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "^5.1.0",
+        "webidl-conversions": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/ms": {
@@ -563,6 +734,15 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/on-headers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.2.tgz",
+      "integrity": "sha512-pZAE+FJLoyITytdqK0U5s+FIpjN0JP3OzFi/u8Rx+EV5/W+JTWGXG8xFzevE7AjBfDqHv/8vL8qQsIhHnqRkrA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -603,6 +783,15 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/qs": {
       "version": "6.14.0",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.0.tgz",
@@ -616,6 +805,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/random-bytes": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/random-bytes/-/random-bytes-1.0.0.tgz",
+      "integrity": "sha512-iv7LhNVO047HzYR3InF6pUcUsPQiHTM1Qal51DcGSuZFBil1aBBWG5eHPNek7bvILMaYJ/8RU1e8w1AMdHmLQQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/range-parser": {
@@ -799,6 +997,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/sparse-bitfield": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/sparse-bitfield/-/sparse-bitfield-3.0.3.tgz",
+      "integrity": "sha512-kvzhi7vqKTfkh0PZU+2D2PIllw2ymqJKujUcyPMd9Y75Nv4nPbGJZXNhxsgdQab2BmlDct1YnfQCguEvHr7VsQ==",
+      "license": "MIT",
+      "dependencies": {
+        "memory-pager": "^1.0.2"
+      }
+    },
     "node_modules/statuses": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
@@ -835,6 +1042,18 @@
       },
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/uid-safe": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/uid-safe/-/uid-safe-2.1.5.tgz",
+      "integrity": "sha512-KPHm4VL5dDXKz01UuEd88Df+KzynaohSL9fBh096KWAxSKZQDI2uBrVqtvRM4rwrIrRRKsdLNML/lnaaVSRioA==",
+      "license": "MIT",
+      "dependencies": {
+        "random-bytes": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/unpipe": {

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "dotenv": "^17.0.0",
     "express": "^5.1.0",
+    "express-session": "^1.18.1",
     "mongodb": "^6.5.0",
     "node-fetch": "^2.7.0"
   }

--- a/server.js
+++ b/server.js
@@ -105,6 +105,9 @@ app.post('/API/GEMINI', async (req, res) => {
 });
 
 app.get('/logs', async (req, res) => {
+    if (!req.session.user) {
+        return res.status(401).json({ error: 'Unauthorized access' });
+    }
     try {
         const db = getDB();
         const {

--- a/server.js
+++ b/server.js
@@ -2,6 +2,7 @@
 require('dotenv').config();
 
 const express = require('express');
+const session = require('express-session');
 const fetch = require('node-fetch');
 const { connectDB, getDB } = require('./db');
 
@@ -11,25 +12,42 @@ const port = 3000;
 // Middleware to serve your HTML, CSS, JS files
 app.use(express.static('.')); // Serves files from the root project folder
 app.use(express.json());      // Middleware to parse JSON bodies
+app.use(session({
+    secret: process.env.SESSION_SECRET || 'secret',
+    resave: false,
+    saveUninitialized: true
+}));
+
+const users = {
+    [process.env.ADMIN_USERNAME || 'admin']: process.env.ADMIN_PASSWORD || 'password'
+};
+
+app.post('/login', (req, res) => {
+    const { username, password } = req.body;
+    if (users[username] && users[username] === password) {
+        req.session.user = username;
+        return res.json({ success: true });
+    }
+    res.status(401).json({ error: 'Invalid credentials' });
+});
+
+app.post('/logout', (req, res) => {
+    req.session.destroy(() => {
+        res.json({ success: true });
+    });
+});
 
 // The new secure API endpoint for your frontend to call
 app.post('/API/GEMINI', async (req, res) => {
     const apiKey = process.env.GEMINI_API_KEY;
     const userPrompt = req.body.prompt;
     const isVariation = req.body.isVariation;
+    const user = req.session.user;
 
-    try {
-        const db = getDB();
-        await db.collection('prompts').insertOne({
-            prompt: userPrompt,
-            isVariation,
-            timestamp: new Date(),
-            ip: req.ip
-        });
-    } catch (dbError) {
-        console.error('Error saving prompt to DB:', dbError);
-        // We can choose to not fail the whole request if DB write fails
+    if (!user) {
+        return res.status(401).json({ error: 'Not authenticated' });
     }
+
 
     if (!apiKey) {
         return res.status(500).json({ error: 'API key not configured on server.' });
@@ -66,6 +84,20 @@ app.post('/API/GEMINI', async (req, res) => {
         const data = await geminiResponse.json();
         res.json(data); // Forward Gemini's response to the frontend
 
+        try {
+            const db = getDB();
+            await db.collection('prompts').insertOne({
+                prompt: userPrompt,
+                isVariation,
+                timestamp: new Date(),
+                ip: req.ip,
+                user,
+                response: data
+            });
+        } catch (dbError) {
+            console.error('Error saving prompt to DB:', dbError);
+        }
+
     } catch (error) {
         console.error('Error calling Gemini API:', error);
         res.status(500).json({ error: 'Failed to call Gemini API.' });
@@ -75,8 +107,39 @@ app.post('/API/GEMINI', async (req, res) => {
 app.get('/logs', async (req, res) => {
     try {
         const db = getDB();
-        const prompts = await db.collection('prompts').find({}).sort({ timestamp: -1 }).limit(100).toArray();
-        res.json(prompts);
+        const {
+            ip,
+            user,
+            start,
+            end,
+            sort = 'desc',
+            page = 1,
+            limit = 20
+        } = req.query;
+
+        const query = {};
+        if (ip) query.ip = ip;
+        if (user) query.user = user;
+        if (start || end) {
+            query.timestamp = {};
+            if (start) query.timestamp.$gte = new Date(start);
+            if (end) query.timestamp.$lte = new Date(end);
+        }
+
+        const sortOrder = sort === 'asc' ? 1 : -1;
+        const skip = (parseInt(page) - 1) * parseInt(limit);
+
+        const prompts = await db
+            .collection('prompts')
+            .find(query)
+            .sort({ timestamp: sortOrder })
+            .skip(skip)
+            .limit(parseInt(limit))
+            .toArray();
+
+        const total = await db.collection('prompts').countDocuments(query);
+
+        res.json({ prompts, total });
     } catch (error) {
         console.error('Error fetching logs from DB:', error);
         res.status(500).json({ error: 'Failed to fetch logs.' });

--- a/server.js
+++ b/server.js
@@ -15,7 +15,11 @@ app.use(express.json());      // Middleware to parse JSON bodies
 app.use(session({
     secret: process.env.SESSION_SECRET || 'secret',
     resave: false,
-    saveUninitialized: true
+    saveUninitialized: true,
+    cookie: {
+        httpOnly: true,
+        secure: process.env.NODE_ENV === 'production'
+    }
 }));
 
 const users = {


### PR DESCRIPTION
## Summary
- add simple session-based login and logout routes
- require authentication for Gemini API requests and log the Gemini response
- make logs endpoint filterable with pagination and sorting
- enhance logs UI with filter form and pagination controls
- add login page and link to it from the main site
- document new environment variables and update features list
- provide `.env.example` for easy setup

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68635d585e88832b95793ce2c9d66f72